### PR TITLE
Support alternative launch name

### DIFF
--- a/infrared_plugin/plugin.spec
+++ b/infrared_plugin/plugin.spec
@@ -75,6 +75,9 @@ subparsers:
                       help: |
                         Path to a directory that will contain files with the ID
                         and the UUID of the newly created launch
+                  launch-altname:
+                      type: Value
+                      help: Override jenkins-name as launch name if defined
                   post-validations:
                       type: Bool
                       help: |

--- a/tasks/import/main.yml
+++ b/tasks/import/main.yml
@@ -13,7 +13,7 @@
     ssl_verify: "{{ ssl_verify | bool }}"
     ignore_skipped_tests: "{{ ignore_skipped_tests | bool }}"
     project_name: "{{ project }}"
-    launch_name: "{{ jenkins_job_name }}"
+    launch_name: "{{ other.launch.altname|default(false) | ternary (other.launch.altname, jenkins_job_name) }}"
     launch_tags: "{{ tags }}"
     launch_description: "{{ launch_description }}"
     launch_start_time: "{{ launch_start_time | default(omit) }}"


### PR DESCRIPTION
On OSASINFRA DFG we are using a single ocp_testing job that, depending
on the provided configuration, will run different testsuites. In order
to keep the control of the test results with ReportPortal, we need to
have different launch names depending on the configuration so we can
compare the results between equivalent runs.

This patch includes the possibility to define a new parameter on the
infrared reportportal plugin called '--launch-altname'. If the
parameter is not included, the behaviour of the plugin is the same
as before this patch.